### PR TITLE
Add additional mail infos to template

### DIFF
--- a/mail/send_mails.py
+++ b/mail/send_mails.py
@@ -126,7 +126,7 @@ def main():
             sender,
             attendee["Mail"],
             subject,
-            text_template.format(**attendee),
+            text_template.format(**mail_info, **attendee),
             "../packages/{}.zip".format(attendee["Short"]),
         )
         send_message(service, "me", msg)


### PR DESCRIPTION
This allows the user to access top level elements like `course: "LFD459"` and use them in the mail template.