### PR TITLE
add passwords to package (if exist)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,8 @@ resource "null_resource" "cluster" {
   triggers = {
     ips  = "${module.student_workspace.ips_checksum}"
     keys = "${module.student_workspace.keys_checksum}"
-  }
+    passwords = join(",",flatten(module.wetty_server.*.student_passwords_hash))
+   }
 
   provisioner "local-exec" {
     command = "./scripts/create_package.sh"

--- a/modules/wetty_server/outputs.tf
+++ b/modules/wetty_server/outputs.tf
@@ -1,3 +1,7 @@
 output "wetty_server_address" {
   value = "https://${trimsuffix(openstack_dns_recordset_v2.wetty.name, ".")}"
 }
+
+output "student_passwords_hash" {
+  value = [ for entry in random_password.student_password: sha256(entry.result) ]
+}

--- a/scripts/create_package.sh
+++ b/scripts/create_package.sh
@@ -15,5 +15,5 @@ do
   FILENAME=${FILENAME%.*}
   echo "Create package for ${FILENAME}"
   puttygen "./keys/${FILENAME}" -O private -o "keys/${FILENAME}.ppk"
-  zip "${DEST}/${FILENAME}.zip" "./keys/${FILENAME}" "./keys/${FILENAME}.ppk" "./ips/${FILENAME}.txt"
+  zip "${DEST}/${FILENAME}.zip" "./keys/${FILENAME}" "./keys/${FILENAME}.ppk" "./ips/${FILENAME}.txt" "./passwords/${FILENAME}"
 done


### PR DESCRIPTION
`zip` will output a warning if the file doesn't exist, but the code will still work (this would be the case, when wetty is unused).