### PR TITLE
fix: variable naming in send_mails

### DIFF
--- a/mail/send_mails.py
+++ b/mail/send_mails.py
@@ -80,15 +80,15 @@ def send_message(service, user_id, message):
     Returns:
       Sent Message.
     """
-    message = None
+    response = None
     try:
-        message = (
+        response = (
             service.users().messages().send(userId=user_id, body=message).execute()
         )
-        print(f"Message Id: {message['id']}")
+        print(f"Message Id: {response['id']}")
     except errors.HttpError as error:
         print(f"An error occurred: {error}")
-    return message
+    return response
 
 
 def render_body(**kwargs):


### PR DESCRIPTION
Now,  this is a bit embarassing but not completely my mistake. The double usage of `message` as parameter as well as response value was already in place. It became a problem when I refactored the function and adde3d the `None` default in the previous PR, effectively overwriting the parameter. The GMail API does not like `None` as a message body ...

What's embarrassing that I had obviously never run the code after the refactoring. This code has been run successfully, though.