### PR TITLE
Improve login script

### DIFF
--- a/scripts/log_me_in.sh
+++ b/scripts/log_me_in.sh
@@ -14,7 +14,7 @@ menu_from_array ()
             echo -n $item
             break;
         else
-            echo "Wrong selection: Select any number from 1-$#"
+            echo >&2 "Wrong selection: Select any number from 1-$#"
         fi
     done
 }

--- a/scripts/log_me_in.sh
+++ b/scripts/log_me_in.sh
@@ -11,7 +11,7 @@ menu_from_array ()
         # Check the selected menu item number
         if [ 1 -le "$REPLY" ] && [ "$REPLY" -le $# ];
         then
-            student=$item
+            echo -n $item
             break;
         else
             echo "Wrong selection: Select any number from 1-$#"
@@ -26,11 +26,12 @@ do
     students+=("${student%.*}")
 done
 
-menu_from_array "${students[@]}"
+student=$(menu_from_array "${students[@]}")
+hosts=($(cat ips/${student}.txt | cut -d: -f1 ))
+host=$(menu_from_array "${hosts[@]}" )
 
 # Find the script location. Inspired by: https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
 scriptLocation="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# fetch first ip address
-ip=$(head -n 1 "${scriptLocation}/../ips/${student}.txt" | awk -F' ' '{print $2}')
-ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i "keys/${student}" "student@${ip}"
+fqdn="${host}.training-lf-kubernetes.fra.ics.inovex.io"
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i "keys/${student}" "student@${fqdn}"


### PR DESCRIPTION
The script was already very helpful. With this PR it becomes even more helpful!

- Presents a second menu to select the host to connect to.
- Uses the host's DNS name.

        $ scripts/log_me_in.sh
        1) henning   3) peter       5) wilhelm
        2) horst     4) heinrich    6) hugo
        1
        1) henning-cp        3) henning-secondcp  5) henning-worker
        2) henning-ha-proxy  4) henning-thirdcp
        1
        Warning: Permanently added 'henning-cp.training-lf-kubernetes.fra.ics.inovex.io' (ED25519) to the list of known hosts.
