### PR TITLE
fix: use ubuntu 20.04 for wetty too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 terraform.tfvars
+training.tfvars
+*.tfplan
 keys
 terraform.tfstate
 terraform.tfstate.backup
@@ -18,3 +20,4 @@ mail/mail_template_en.txt
 mail/mail_info.yaml
 passwords
 solutions.patch
+clouds.yaml

--- a/main.tf
+++ b/main.tf
@@ -35,8 +35,8 @@ module "student_workspace" {
   sec_groups      = [module.network.secgroup_name]
   solutions_url   = var.solutions_url
   solutions_patch = fileexists("${path.module}/solutions.patch") ? filebase64("${path.module}/solutions.patch") : ""
-
-  depends_on = [ module.network ]
+  ubuntu_image    = var.ubuntu_image
+  depends_on      = [module.network]
 }
 
 module "wetty_server" {
@@ -49,6 +49,7 @@ module "wetty_server" {
   trainer       = var.trainer
   sec_groups    = [module.network.secgroup_name]
   instances     = module.student_workspace.instance_info
+  ubuntu_image  = var.ubuntu_image
   dns_domain    = var.dns_domain
   trainer_email = var.wetty_config.trainer_email
 }

--- a/modules/student_workspace/data.tf
+++ b/modules/student_workspace/data.tf
@@ -3,7 +3,7 @@ data "openstack_networking_network_v2" "public" {
 }
 
 data "openstack_images_image_v2" "ubuntu" {
-  name        = "ubuntu-20.04-x86_64"
+  name        = var.ubuntu_image
   most_recent = true
   visibility  = "public"
 }

--- a/modules/student_workspace/variables.tf
+++ b/modules/student_workspace/variables.tf
@@ -40,3 +40,7 @@ variable "dns_domain" {
   type    = string
   default = ""
 }
+
+variable "ubuntu_image" {
+  type = string
+}

--- a/modules/wetty_server/data.tf
+++ b/modules/wetty_server/data.tf
@@ -3,11 +3,7 @@ data "openstack_networking_network_v2" "public" {
 }
 
 data "openstack_images_image_v2" "ubuntu" {
+  name        = var.ubuntu_image
   most_recent = true
   visibility  = "public"
-
-  properties = {
-    os_distro  = "ubuntu"
-    os_version = "18.04"
-  }
 }

--- a/modules/wetty_server/variables.tf
+++ b/modules/wetty_server/variables.tf
@@ -53,3 +53,7 @@ variable "wetty_image" {
   type    = string
   default = "wettyoss/wetty" # FIXME: Pin?
 }
+
+variable "ubuntu_image" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,8 @@ variable "solutions_patch" {
   type        = string
   default     = ""
 }
+
+variable "ubuntu_image" {
+  type    = string
+  default = "ubuntu-20.04-x86_64"
+}


### PR DESCRIPTION
We are using Ubuntu 20.04 for the cp and worker nodes. However, Wetty VM was using Ubuntu 18.04.

Since 18.04. is not available anymore, I decided to align this for all machines using 20.04.